### PR TITLE
fix: cli: exit peacefully on --help and --version

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,17 @@ use glitter::config::Arguments;
 use structopt::StructOpt;
 
 fn main() -> anyhow::Result<()> {
-	glitter::run(Arguments::from_args_safe()?)?;
-
-	Ok(())
+	match Arguments::from_args_safe() {
+		Ok(args) => glitter::run(args),
+		Err(err) => {
+			if err.use_stderr() {
+				Err(err.into())
+			} else {
+				println!("{}", err.message);
+				Ok(())
+			}
+		}
+	}
 }
 // tests
 #[cfg(test)]


### PR DESCRIPTION
my last pull request (#92) caused `--help` and `--version` to exit with an error, this should be able to fix it

also if would be nice if you could create a new version once this is merged